### PR TITLE
Fixed NPE in NetworkController when BluetoothAdapter is null

### DIFF
--- a/debugdrawer/src/main/java/io/palaima/debugdrawer/controller/NetworkController.java
+++ b/debugdrawer/src/main/java/io/palaima/debugdrawer/controller/NetworkController.java
@@ -135,7 +135,7 @@ public class NetworkController {
      * True if bluetooth is enabled
      */
     public boolean isBluetoothEnabled() {
-        return mBluetoothAdapter.isEnabled();
+        return mBluetoothAdapter != null && mBluetoothAdapter.isEnabled();
     }
 
     /**


### PR DESCRIPTION
I've got that issue on a GenyMotion Device. I don't know if that's the reason, in any case it should not crash since now I can't use the NetworkModule.