### PR TITLE
Cleaned string resources up and added DS_STORE files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ signing.properties
 build/
 
 *.jks
+
+# Mac OS
+.DS_STORE

--- a/debugdrawer-okhttp/src/main/AndroidManifest.xml
+++ b/debugdrawer-okhttp/src/main/AndroidManifest.xml
@@ -1,10 +1,6 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="io.palaima.debugdrawer.okhttp">
+<manifest package="io.palaima.debugdrawer.okhttp"
+          xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <application android:allowBackup="true"
-                 android:label="@string/app_name"
-        >
-
-    </application>
+    <application android:allowBackup="true"/>
 
 </manifest>

--- a/debugdrawer-okhttp/src/main/res/values/strings.xml
+++ b/debugdrawer-okhttp/src/main/res/values/strings.xml
@@ -1,3 +1,0 @@
-<resources>
-    <string name="app_name">OkHttp Module</string>
-</resources>

--- a/debugdrawer-picasso/src/main/AndroidManifest.xml
+++ b/debugdrawer-picasso/src/main/AndroidManifest.xml
@@ -1,10 +1,6 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="io.palaima.debugdrawer.picasso">
+<manifest package="io.palaima.debugdrawer.picasso"
+          xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <application android:allowBackup="true"
-                 android:label="@string/app_name"
-        >
-
-    </application>
+    <application android:allowBackup="true"/>
 
 </manifest>

--- a/debugdrawer-picasso/src/main/res/values/strings.xml
+++ b/debugdrawer-picasso/src/main/res/values/strings.xml
@@ -1,3 +1,0 @@
-<resources>
-    <string name="app_name">Debug Drawer Picasso</string>
-</resources>

--- a/debugdrawer-scalpel/src/main/AndroidManifest.xml
+++ b/debugdrawer-scalpel/src/main/AndroidManifest.xml
@@ -1,8 +1,6 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="io.palaima.debugdrawer.scalpel">
+<manifest package="io.palaima.debugdrawer.scalpel"
+          xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <application android:allowBackup="true">
-
-    </application>
+    <application android:allowBackup="true"/>
 
 </manifest>

--- a/debugdrawer-scalpel/src/main/res/values/strings.xml
+++ b/debugdrawer-scalpel/src/main/res/values/strings.xml
@@ -1,2 +1,0 @@
-<resources>
-</resources>


### PR DESCRIPTION
The problem of having those unnecessary string resources is:

> Manifest merger failed : Attribute application@label value=(@string/client_name) from (unknown)
    is also present at io.palaima.debugdrawer:debugdrawer-okhttp:0.2.0:13:9 value=(@string/app_name)
    Suggestion: add 'tools:replace="android:label"' to <application> element at AndroidManifest.xml:32:5 to override