### PR TITLE
Fixed NPE in NetworkController

### DIFF
--- a/debugdrawer/src/main/java/io/palaima/debugdrawer/controller/NetworkController.java
+++ b/debugdrawer/src/main/java/io/palaima/debugdrawer/controller/NetworkController.java
@@ -24,6 +24,7 @@ import android.content.IntentFilter;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import android.net.wifi.WifiManager;
+import android.support.annotation.Nullable;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
@@ -193,29 +194,29 @@ public class NetworkController {
      * a NetworkChangeEvent using listener
      * <p/>
      */
-    public class NetworkReceiver extends BroadcastReceiver {
-
-
+    public static class NetworkReceiver extends BroadcastReceiver {
+        @Nullable
         private final Listener mListener;
 
-        public NetworkReceiver(Listener listener) {
+        public NetworkReceiver(@Nullable Listener listener) {
             mListener = listener;
         }
 
         @Override
         public void onReceive(Context context, Intent intent) {
-            ConnectivityManager connectivityManager = (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
-
-            NetworkInfo wifiInfo = connectivityManager.getNetworkInfo(ConnectivityManager.TYPE_WIFI);
-            NetworkInfo mobileInfo = connectivityManager.getNetworkInfo(ConnectivityManager.TYPE_MOBILE);
-
-            final int bluetoothState = BluetoothAdapter.getDefaultAdapter().getState();
-
             if (mListener != null) {
-                mListener.post(new NetworkChangeEvent(
+                ConnectivityManager connectivityManager = (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
+
+                NetworkInfo wifiInfo = connectivityManager.getNetworkInfo(ConnectivityManager.TYPE_WIFI);
+                NetworkInfo mobileInfo = connectivityManager.getNetworkInfo(ConnectivityManager.TYPE_MOBILE);
+                BluetoothAdapter bluetoothInfo = BluetoothAdapter.getDefaultAdapter();
+
+                final NetworkChangeEvent networkChangeEvent = new NetworkChangeEvent(
                         (wifiInfo != null) ? wifiInfo.getState() : NetworkInfo.State.UNKNOWN,
                         (mobileInfo != null) ? mobileInfo.getState() : NetworkInfo.State.UNKNOWN,
-                        getBluetoothState(bluetoothState)));
+                        (bluetoothInfo != null) ? getBluetoothState(bluetoothInfo.getState()) : BluetoothState.Unknown);
+
+                mListener.post(networkChangeEvent);
             }
 
         }
@@ -242,8 +243,7 @@ public class NetworkController {
         }
     }
 
-    public class NetworkChangeEvent {
-
+    public static class NetworkChangeEvent {
         public final NetworkInfo.State wifiState;
         public final NetworkInfo.State mobileState;
         public final BluetoothState bluetoothState;


### PR DESCRIPTION
This one will fix

>     java.lang.RuntimeException: Error receiving broadcast Intent { act=android.net.conn.CONNECTIVITY_CHANGE flg=0x4000010 (has extras) } in io.palaima.debugdrawer.controller.NetworkController$NetworkReceiver@141e3f33
            at android.app.LoadedApk$ReceiverDispatcher$Args.run(LoadedApk.java:871)
            at android.os.Handler.handleCallback(Handler.java:739)
            at android.os.Handler.dispatchMessage(Handler.java:95)
            at android.os.Looper.loop(Looper.java:135)
            at android.app.ActivityThread.main(ActivityThread.java:5221)
            at java.lang.reflect.Method.invoke(Native Method)
            at java.lang.reflect.Method.invoke(Method.java:372)
            at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:899)
            at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:694)
     Caused by: java.lang.NullPointerException: Attempt to invoke virtual method 'int android.bluetooth.BluetoothAdapter.getState()' on a null object reference
            at io.palaima.debugdrawer.controller.NetworkController$NetworkReceiver.onReceive(NetworkController.java:212)
            at android.app.LoadedApk$ReceiverDispatcher$Args.run(LoadedApk.java:861)

Furthermore the inner classes are now static (they should be) otherwise they have a reference to the parent and a memory leak might occur.

Would you mind releasing version 0.2.1 including the two pull requests that I've created?

Thank you very much.