### PR TITLE
Fix Picasso module's indicators current switch state

### DIFF
--- a/debugdrawer-picasso/src/main/java/io/palaima/debugdrawer/picasso/PicassoModule.java
+++ b/debugdrawer-picasso/src/main/java/io/palaima/debugdrawer/picasso/PicassoModule.java
@@ -51,7 +51,7 @@ public class PicassoModule implements DrawerModule {
 
 
         mPicasso.setIndicatorsEnabled(mPicasso.areIndicatorsEnabled());
-        mIndicator.setChecked(false);
+        mIndicator.setChecked(mPicasso.areIndicatorsEnabled());
         mIndicator.setOnCheckedChangeListener(
                 new CompoundButton.OnCheckedChangeListener() {
                     @Override


### PR DESCRIPTION
Getting the current state of Picasso's indicators and reflect it on the drawer's switch state.