### PR TITLE
Decouples the Debug View from the Drawer

### DIFF
--- a/debugdrawer/src/main/java/io/palaima/debugdrawer/DebugDrawer.java
+++ b/debugdrawer/src/main/java/io/palaima/debugdrawer/DebugDrawer.java
@@ -363,7 +363,7 @@ public class DebugDrawer {
                 UIUtils.setBackground(mSliderLayout, mSliderBackgroundColorRes);
             }
 
-            mDebugView.init(mDrawerItems);
+            mDebugView.initModules(mDrawerItems);
 
             //create the result object
             DebugDrawer result = new DebugDrawer(this);

--- a/debugdrawer/src/main/java/io/palaima/debugdrawer/DebugView.java
+++ b/debugdrawer/src/main/java/io/palaima/debugdrawer/DebugView.java
@@ -44,7 +44,7 @@ public class DebugView extends LinearLayout {
         }
     }
 
-    public void init(DrawerModule... drawerItems) {
+    public void initModules(DrawerModule... drawerItems) {
         mDrawerItems = drawerItems;
         LayoutInflater inflater = LayoutInflater.from(getContext());
         if (this.mDrawerItems != null && !(this.mDrawerItems.length == 0)) {

--- a/debugdrawer/src/main/java/io/palaima/debugdrawer/DebugView.java
+++ b/debugdrawer/src/main/java/io/palaima/debugdrawer/DebugView.java
@@ -1,0 +1,58 @@
+package io.palaima.debugdrawer;
+
+import android.content.Context;
+import android.util.AttributeSet;
+import android.view.LayoutInflater;
+import android.widget.LinearLayout;
+
+import io.palaima.debugdrawer.module.DrawerModule;
+
+public class DebugView extends LinearLayout {
+
+    private DrawerModule[] mDrawerItems;
+
+    public DebugView(Context context) {
+        super(context);
+        setOrientation(VERTICAL);
+    }
+
+    public DebugView(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        setOrientation(VERTICAL);
+    }
+
+    public DebugView(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+        setOrientation(VERTICAL);
+    }
+
+    /**
+     * Starts all modules and calls their {@link DrawerModule#onStart()} method
+     */
+    public void onStart() {
+        for (DrawerModule drawerItem : mDrawerItems) {
+            drawerItem.onStart();
+        }
+    }
+
+    /**
+     * Removes all modules and calls their {@link DrawerModule#onStop()} method
+     */
+    public void onStop() {
+        for (DrawerModule drawerItem : mDrawerItems) {
+            drawerItem.onStop();
+        }
+    }
+
+    public void init(DrawerModule... drawerItems) {
+        mDrawerItems = drawerItems;
+        LayoutInflater inflater = LayoutInflater.from(getContext());
+        if (this.mDrawerItems != null && !(this.mDrawerItems.length == 0)) {
+            DrawerModule drawerItem;
+            for (int i = 0; i < this.mDrawerItems.length; i++) {
+                drawerItem = this.mDrawerItems[i];
+                addView(drawerItem.onCreateView(inflater, this));
+            }
+        }
+    }
+}

--- a/debugdrawer/src/main/res/layout/debug_drawer.xml
+++ b/debugdrawer/src/main/res/layout/debug_drawer.xml
@@ -14,4 +14,6 @@
         android:id="@+id/content_layout"
         android:layout_width="match_parent"
         android:layout_height="match_parent"/>
+
+    <include layout="@layout/debug_drawer_slider" />
 </android.support.v4.widget.DrawerLayout>

--- a/debugdrawer/src/main/res/layout/debug_drawer_slider.xml
+++ b/debugdrawer/src/main/res/layout/debug_drawer_slider.xml
@@ -11,9 +11,8 @@
     android:layout_marginEnd="@dimen/debug_drawer_margin"
     android:background="#ee212121">
 
-        <LinearLayout
-            android:id="@+id/container"
-            android:orientation="vertical"
+        <io.palaima.debugdrawer.DebugView
+            android:id="@+id/debug_view"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"/>
 </ScrollView>


### PR DESCRIPTION
> This separates the debug view content itself from the drawer, so that it can be used in any custom layout.
Extracts the module inflation to a custom View that can be instantiated manually, making the DebugDrawer Builder use it underneath.

Hi! I liked this library a lot for it's modularity. I already had a custom debug drawer on my application and  I was planning to create a similar project to this one. I has appy to see that someone already had that idea and it looks great :)

But I found a problem when integrating in on my project: the default behaviour is great for most apps, it's amazingly easy to setup. My case is a bit different, and I need something a bit more custom-made. I need to add some modifications to the debug drawer so that it looks good in my layouts. And also but not less important, I want to use these debug modules beyond the debug drawer, like in a dedicated activity as seen in recent versions of the u2020 project.

So, back to the pull request, I made some modifications to allow using a `DebugView` which handles the modules without having to use the full DebugDrawer features.

I tested it, both in the demo app and in my project, and it seems to work. I'm creating the pull request so you can check my idea out and tell me what you think. If you think it could be usefull and want to integrate it into the library, I should probably add something to the readme or the demo app.

Also, there is one thing that I didn't cover yet: how to trigger `onOpen()` and `onClose()` events in the custom view. Maybe inform the user of the library that they must manually invoke this events if they choose to use de DebugView by their own? I'd like your opinion on that.
 
Waiting for your response.
Thanks for the library!