### PR TITLE
Fix SecurityException in NetworkController regarding missing Bluetooth permission

### DIFF
--- a/debugdrawer-commons/src/main/java/io/palaima/debugdrawer/commons/NetworkController.java
+++ b/debugdrawer-commons/src/main/java/io/palaima/debugdrawer/commons/NetworkController.java
@@ -17,11 +17,13 @@
 
 package io.palaima.debugdrawer.commons;
 
+import android.Manifest;
 import android.bluetooth.BluetoothAdapter;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.content.pm.PackageManager;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import android.net.wifi.WifiManager;
@@ -139,7 +141,11 @@ final class NetworkController {
      * @return True if bluetooth is enabled
      */
     public boolean isBluetoothEnabled() {
-        return isBluetoothAvailable() && bluetoothAdapter.isEnabled();
+        return isBluetoothAvailable() && hasBlueBoothPermission() && bluetoothAdapter.isEnabled();
+    }
+
+    private boolean hasBlueBoothPermission() {
+        return context.checkCallingOrSelfPermission(Manifest.permission.BLUETOOTH) == PackageManager.PERMISSION_GRANTED;
     }
 
     /**


### PR DESCRIPTION
Fixes

> 01-19 11:23:01.828 4500-4500/? E/AndroidRuntime: FATAL EXCEPTION: main
                                                 Process: net.familo.android.dev, PID: 4500
                                                 java.lang.SecurityException: Need BLUETOOTH ADMIN permission: Neither user 10119 nor current process has android.permission.BLUETOOTH_ADMIN.
                                                     at android.os.Parcel.readException(Parcel.java:1620)
                                                     at android.os.Parcel.readException(Parcel.java:1573)
                                                     at android.bluetooth.IBluetoothManager$Stub$Proxy.enable(IBluetoothManager.java:302)
                                                     at android.bluetooth.BluetoothAdapter.enable(BluetoothAdapter.java:901)
                                                     at io.palaima.debugdrawer.commons.NetworkController.setBluetoothEnabled(NetworkController.java:152)
                                                     at io.palaima.debugdrawer.commons.NetworkModule$3.onCheckedChanged(NetworkModule.java:78)
                                                     at android.widget.CompoundButton.setChecked(CompoundButton.java:156)
                                                     at android.widget.Switch.setChecked(Switch.java:1070)
                                                     at android.widget.Switch.toggle(Switch.java:1065)
                                                     at android.widget.CompoundButton.performClick(CompoundButton.java:120)
                                                     at android.view.View$PerformClick.run(View.java:21153)
                                                     at android.os.Handler.handleCallback(Handler.java:739)
                                                     at android.os.Handler.dispatchMessage(Handler.java:95)
                                                     at android.os.Looper.loop(Looper.java:148)
                                                     at android.app.ActivityThread.main(ActivityThread.java:5417)
                                                     at java.lang.reflect.Method.invoke(Native Method)
                                                     at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:726)
                                                     at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:616)