### PR TITLE
Fixing squid:S00108 - Nested blocks of code should not be left empty

### DIFF
--- a/debugdrawer-commons/src/main/java/io/palaima/debugdrawer/commons/BuildModule.java
+++ b/debugdrawer-commons/src/main/java/io/palaima/debugdrawer/commons/BuildModule.java
@@ -22,6 +22,7 @@ import android.content.pm.PackageManager;
 import android.support.annotation.NonNull;
 import android.view.LayoutInflater;
 import android.view.View;
+import android.util.Log;
 import android.view.ViewGroup;
 import android.widget.TextView;
 
@@ -81,7 +82,9 @@ public class BuildModule implements DebugModule {
             codeLabel.setText(String.valueOf(info.versionCode));
             nameLabel.setText(info.versionName);
             packageLabel.setText(info.packageName);
-        } catch (PackageManager.NameNotFoundException e) {}
+        } catch (PackageManager.NameNotFoundException e) {
+        	Log.e("PackageManager.NameNotFoundException", e);
+        }
     }
 
     @Override

--- a/debugdrawer-commons/src/main/java/io/palaima/debugdrawer/commons/NetworkController.java
+++ b/debugdrawer-commons/src/main/java/io/palaima/debugdrawer/commons/NetworkController.java
@@ -25,6 +25,7 @@ import android.content.IntentFilter;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import android.net.wifi.WifiManager;
+import android.util.Log;
 import android.support.annotation.Nullable;
 
 import java.lang.reflect.Field;
@@ -120,10 +121,15 @@ final class NetworkController {
             setMobileDataEnabledMethod.invoke(iConnectivityManager, enabled);
             return true;
         } catch (ClassNotFoundException e) {
+        	Log.e("ClassNotFoundException", e);
         } catch (InvocationTargetException e) {
+        	Log.e("InvocationTargetException", e);
         } catch (NoSuchMethodException e) {
+        	Log.e("NoSuchMethodException", e);
         } catch (IllegalAccessException e) {
+        	Log.e("IllegalAccessException", e);
         } catch (NoSuchFieldException e) {
+        	Log.e("NoSuchFieldException", e);
         }
         return false;
     }
@@ -161,6 +167,7 @@ final class NetworkController {
         try {
             context.unregisterReceiver(receiver);
         } catch (IllegalArgumentException e) {
+        	Log.e("IllegalArgumentException", e);
         }
     }
 

--- a/debugdrawer/src/main/java/io/palaima/debugdrawer/util/UIUtils.java
+++ b/debugdrawer/src/main/java/io/palaima/debugdrawer/util/UIUtils.java
@@ -21,6 +21,7 @@ import android.content.Context;
 import android.content.res.TypedArray;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
+import android.util.Log;
 import android.util.DisplayMetrics;
 import android.view.View;
 
@@ -70,6 +71,7 @@ public class UIUtils {
                 d = c.getResources().getDrawable(drawableRes, c.getTheme());
             }
         } catch (Exception ex) {
+        	Log.e("ClassNotFoundException", e);
         }
         return d;
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule "squid:S00108 - Nested blocks of code should not be left empty". You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/squid:S00108

Please let me know if you have any questions.
Sameer Misger
