### PR TITLE
Fixing squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order

### DIFF
--- a/app/src/main/java/io/palaima/debugdrawer/app/DebugViewActivity.java
+++ b/app/src/main/java/io/palaima/debugdrawer/app/DebugViewActivity.java
@@ -37,6 +37,8 @@ import timber.log.Timber;
 
 public class DebugViewActivity extends AppCompatActivity {
 
+	private static final int DISK_CACHE_SIZE = 50 * 1024 * 1024; // 50 MB
+
     private Toolbar toolbar;
 
     private DebugView debugView;
@@ -142,8 +144,6 @@ public class DebugViewActivity extends AppCompatActivity {
         }
         return toolbar;
     }
-
-    private static final int DISK_CACHE_SIZE = 50 * 1024 * 1024; // 50 MB
 
     private static OkHttpClient createOkHttpClient(Application application) {
         final OkHttpClient client = new OkHttpClient();

--- a/app/src/main/java/io/palaima/debugdrawer/app/MainActivity.java
+++ b/app/src/main/java/io/palaima/debugdrawer/app/MainActivity.java
@@ -43,6 +43,8 @@ import timber.log.Timber;
 
 public class MainActivity extends AppCompatActivity {
 
+    private static final int DISK_CACHE_SIZE = 50 * 1024 * 1024; // 50 MB
+
     private Toolbar toolbar;
 
     private DebugDrawer debugDrawer;
@@ -183,8 +185,6 @@ public class MainActivity extends AppCompatActivity {
         }
         return toolbar;
     }
-
-    private static final int DISK_CACHE_SIZE = 50 * 1024 * 1024; // 50 MB
 
     private static OkHttpClient createOkHttpClient(Application application) {
         final OkHttpClient client = new OkHttpClient();

--- a/debugdrawer-actions/src/main/java/io/palaima/debugdrawer/actions/SwitchAction.java
+++ b/debugdrawer-actions/src/main/java/io/palaima/debugdrawer/actions/SwitchAction.java
@@ -22,6 +22,16 @@ public class SwitchAction implements Action {
     private Context context;
     private Switch  switchButton;
 
+    private CompoundButton.OnCheckedChangeListener switchListener = new CompoundButton.OnCheckedChangeListener() {
+        @Override
+        public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
+            if (listener != null) {
+                listener.onCheckedChanged(isChecked);
+            }
+            writeValue(isChecked);
+        }
+    };
+
     public SwitchAction(String name, Listener listener) {
         this.name = name;
         this.listener = listener;
@@ -90,16 +100,6 @@ public class SwitchAction implements Action {
     public void onStop() {
         /* no-op */
     }
-
-    private CompoundButton.OnCheckedChangeListener switchListener = new CompoundButton.OnCheckedChangeListener() {
-        @Override
-        public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
-            if (listener != null) {
-                listener.onCheckedChanged(isChecked);
-            }
-            writeValue(isChecked);
-        }
-    };
 
     public boolean isChecked() {
         return readValue();

--- a/debugdrawer-commons/src/main/java/io/palaima/debugdrawer/commons/NetworkController.java
+++ b/debugdrawer-commons/src/main/java/io/palaima/debugdrawer/commons/NetworkController.java
@@ -52,13 +52,7 @@ final class NetworkController {
     private transient Context context;
 
     private OnNetworkChangedListener onNetworkChangedListener;
-
-    public static NetworkController newInstance(Context context) {
-        if (instance == null)
-            instance = new NetworkController(context);
-        return instance;
-    }
-
+    
     /**
      * Controller responsible for switching states related to networks.
      * E.g. wifi, mobile networks
@@ -71,6 +65,13 @@ final class NetworkController {
         connectivityManager = (ConnectivityManager) this.context.getSystemService(Context.CONNECTIVITY_SERVICE);
         bluetoothAdapter = BluetoothAdapter.getDefaultAdapter();
     }
+
+    public static NetworkController newInstance(Context context) {
+        if (instance == null)
+            instance = new NetworkController(context);
+        return instance;
+    }
+
 
     public void setOnNetworkChangedListener(OnNetworkChangedListener listener) {
         onNetworkChangedListener = listener;

--- a/debugdrawer-commons/src/main/java/io/palaima/debugdrawer/commons/NetworkModule.java
+++ b/debugdrawer-commons/src/main/java/io/palaima/debugdrawer/commons/NetworkModule.java
@@ -38,6 +38,24 @@ public class NetworkModule implements DebugModule {
     private Switch mobile;
     private Switch bluetooth;
 
+    private NetworkController.OnNetworkChangedListener onNetworkChangedListener = new NetworkController.OnNetworkChangedListener() {
+        @Override
+        public void onChanged(NetworkController.NetworkChangeEvent event) {
+            if (wifi != null) {
+                wifi.setChecked(event.wifiState == NetworkInfo.State.CONNECTED
+                    || event.wifiState == NetworkInfo.State.CONNECTING);
+            }
+            if (mobile != null) {
+                mobile.setChecked(event.mobileState == NetworkInfo.State.CONNECTED
+                    || event.mobileState == NetworkInfo.State.CONNECTING);
+            }
+            if (bluetooth != null) {
+                bluetooth.setChecked(event.bluetoothState == NetworkController.BluetoothState.On
+                    || event.bluetoothState == NetworkController.BluetoothState.Turning_On);
+            }
+        }
+    };
+    
     public NetworkModule(Context context) {
         this.context = context.getApplicationContext();
     }
@@ -117,21 +135,4 @@ public class NetworkModule implements DebugModule {
         networkController.registerReceiver();
     }
 
-    private NetworkController.OnNetworkChangedListener onNetworkChangedListener = new NetworkController.OnNetworkChangedListener() {
-        @Override
-        public void onChanged(NetworkController.NetworkChangeEvent event) {
-            if (wifi != null) {
-                wifi.setChecked(event.wifiState == NetworkInfo.State.CONNECTED
-                    || event.wifiState == NetworkInfo.State.CONNECTING);
-            }
-            if (mobile != null) {
-                mobile.setChecked(event.mobileState == NetworkInfo.State.CONNECTED
-                    || event.mobileState == NetworkInfo.State.CONNECTING);
-            }
-            if (bluetooth != null) {
-                bluetooth.setChecked(event.bluetoothState == NetworkController.BluetoothState.On
-                    || event.bluetoothState == NetworkController.BluetoothState.Turning_On);
-            }
-        }
-    };
 }

--- a/debugdrawer-location/src/main/java/io/palaima/debugdrawer/location/LocationController.java
+++ b/debugdrawer-location/src/main/java/io/palaima/debugdrawer/location/LocationController.java
@@ -40,15 +40,14 @@ public class LocationController implements GoogleApiClient.ConnectionCallbacks,
     private boolean isStarted;
 
     private boolean connected;
-
+    
+    private LocationController(Context context) {
+        buildGoogleApiClient(context);
+    }
     public static LocationController newInstance(Context context) {
         if (instance == null)
             instance = new LocationController(context);
         return instance;
-    }
-
-    private LocationController(Context context) {
-        buildGoogleApiClient(context);
     }
 
     public void setLocationListener(LocationListener listener) {

--- a/debugdrawer-timber/src/main/java/io/palaima/debugdrawer/timber/util/Intents.java
+++ b/debugdrawer-timber/src/main/java/io/palaima/debugdrawer/timber/util/Intents.java
@@ -8,6 +8,9 @@ import android.widget.Toast;
 import java.util.List;
 
 public final class Intents {
+	
+	 private Intents() {
+	 }
     /**
      * Attempt to launch the supplied {@link Intent}. Queries on-device packages before launching and
      * will display a simple message if none are available to handle it.
@@ -31,6 +34,4 @@ public final class Intents {
         return !handlers.isEmpty();
     }
 
-    private Intents() {
-    }
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule "squid:S1213 -  The members of an interface declaration or class should appear in a pre-defined order". You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/squid:S1213

Please let me know if you have any questions.
Sameer Misger
