### PR TITLE
Create adapter for DebugModule to reduce boilerplate code

### DIFF
--- a/debugdrawer-base/src/main/java/io/palaima/debugdrawer/base/DebugModuleAdapter.java
+++ b/debugdrawer-base/src/main/java/io/palaima/debugdrawer/base/DebugModuleAdapter.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2015 Mantas Palaima
+ * Copyright (C) 2016 Oleg Godovykh
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.palaima.debugdrawer.base;
+
+public abstract class DebugModuleAdapter implements DebugModule {
+
+    @Override
+    public void onOpened() {
+        // do nothing
+    }
+
+    @Override
+    public void onClosed() {
+        // do nothing
+    }
+
+    @Override
+    public void onResume() {
+        // do nothing
+    }
+
+    @Override
+    public void onPause() {
+        // do nothing
+    }
+
+    @Override
+    public void onStart() {
+        // do nothing
+    }
+
+    @Override
+    public void onStop() {
+        // do nothing
+    }
+}

--- a/debugdrawer-commons/src/main/java/io/palaima/debugdrawer/commons/BuildModule.java
+++ b/debugdrawer-commons/src/main/java/io/palaima/debugdrawer/commons/BuildModule.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2015 Mantas Palaima
+ * Copyright (C) 2016 Oleg Godovykh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,10 +26,9 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
 
-import io.palaima.debugdrawer.base.DebugModule;
+import io.palaima.debugdrawer.base.DebugModuleAdapter;
 
-public class BuildModule implements DebugModule {
-
+public class BuildModule extends DebugModuleAdapter {
 
     private final Context context;
 
@@ -60,21 +60,6 @@ public class BuildModule implements DebugModule {
         refresh();
     }
 
-    @Override
-    public void onClosed() {
-
-    }
-
-    @Override
-    public void onResume() {
-
-    }
-
-    @Override
-    public void onPause() {
-
-    }
-
     private void refresh() {
         try {
             final PackageInfo info = context.getPackageManager().getPackageInfo(context.getPackageName(), 0);
@@ -82,15 +67,5 @@ public class BuildModule implements DebugModule {
             nameLabel.setText(info.versionName);
             packageLabel.setText(info.packageName);
         } catch (PackageManager.NameNotFoundException e) {}
-    }
-
-    @Override
-    public void onStart() {
-
-    }
-
-    @Override
-    public void onStop() {
-
     }
 }

--- a/debugdrawer-commons/src/main/java/io/palaima/debugdrawer/commons/DeviceModule.java
+++ b/debugdrawer-commons/src/main/java/io/palaima/debugdrawer/commons/DeviceModule.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2015 Mantas Palaima
+ * Copyright (C) 2016 Oleg Godovykh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,9 +26,9 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
 
-import io.palaima.debugdrawer.base.DebugModule;
+import io.palaima.debugdrawer.base.DebugModuleAdapter;
 
-public class DeviceModule implements DebugModule {
+public class DeviceModule extends DebugModuleAdapter {
 
     private String deviceMake;
     private String deviceModel;
@@ -100,35 +101,5 @@ public class DeviceModule implements DebugModule {
         deviceReleaseLabel.setText(deviceRelease);
 
         return view;
-    }
-
-    @Override
-    public void onOpened() {
-
-    }
-
-    @Override
-    public void onClosed() {
-
-    }
-
-    @Override
-    public void onResume() {
-
-    }
-
-    @Override
-    public void onPause() {
-
-    }
-
-    @Override
-    public void onStart() {
-
-    }
-
-    @Override
-    public void onStop() {
-
     }
 }

--- a/debugdrawer-commons/src/main/java/io/palaima/debugdrawer/commons/NetworkModule.java
+++ b/debugdrawer-commons/src/main/java/io/palaima/debugdrawer/commons/NetworkModule.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2015 Mantas Palaima
+ * Copyright (C) 2016 Oleg Godovykh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,9 +27,9 @@ import android.view.ViewGroup;
 import android.widget.CompoundButton;
 import android.widget.Switch;
 
-import io.palaima.debugdrawer.base.DebugModule;
+import io.palaima.debugdrawer.base.DebugModuleAdapter;
 
-public class NetworkModule implements DebugModule {
+public class NetworkModule extends DebugModuleAdapter {
 
     private final Context context;
 
@@ -83,26 +84,6 @@ public class NetworkModule implements DebugModule {
         }
 
         return view;
-    }
-
-    @Override
-    public void onOpened() {
-
-    }
-
-    @Override
-    public void onClosed() {
-
-    }
-
-    @Override
-    public void onResume() {
-
-    }
-
-    @Override
-    public void onPause() {
-
     }
 
     @Override

--- a/debugdrawer-commons/src/main/java/io/palaima/debugdrawer/commons/SettingsModule.java
+++ b/debugdrawer-commons/src/main/java/io/palaima/debugdrawer/commons/SettingsModule.java
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2014 LemonLabs
  * Copyright (C) 2015 Mantas Palaima
+ * Copyright (C) 2016 Oleg Godovykh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,9 +30,9 @@ import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.Toast;
 
-import io.palaima.debugdrawer.base.DebugModule;
+import io.palaima.debugdrawer.base.DebugModuleAdapter;
 
-public class SettingsModule implements DebugModule, View.OnClickListener {
+public class SettingsModule extends DebugModuleAdapter implements View.OnClickListener {
 
     private final Context context;
 
@@ -84,36 +85,6 @@ public class SettingsModule implements DebugModule, View.OnClickListener {
         location.setOnClickListener(this);
         locationTitle.setOnClickListener(this);
         return view;
-    }
-
-    @Override
-    public void onOpened() {
-
-    }
-
-    @Override
-    public void onClosed() {
-
-    }
-
-    @Override
-    public void onResume() {
-
-    }
-
-    @Override
-    public void onPause() {
-
-    }
-
-    @Override
-    public void onStart() {
-
-    }
-
-    @Override
-    public void onStop() {
-
     }
 
     @Override

--- a/debugdrawer-fps/src/main/java/io/palaima/debugdrawer/fps/FpsModule.java
+++ b/debugdrawer-fps/src/main/java/io/palaima/debugdrawer/fps/FpsModule.java
@@ -7,10 +7,10 @@ import android.view.ViewGroup;
 import android.widget.CompoundButton;
 import android.widget.Switch;
 
-import io.palaima.debugdrawer.base.DebugModule;
+import io.palaima.debugdrawer.base.DebugModuleAdapter;
 import jp.wasabeef.takt.Takt;
 
-public class FpsModule implements DebugModule {
+public class FpsModule extends DebugModuleAdapter {
 
     private static final boolean HAS_TAKT;
 
@@ -60,16 +60,6 @@ public class FpsModule implements DebugModule {
     }
 
     @Override
-    public void onOpened() {
-
-    }
-
-    @Override
-    public void onClosed() {
-
-    }
-
-    @Override
     public void onResume() {
         if (isChecked) {
             program.play();
@@ -81,15 +71,5 @@ public class FpsModule implements DebugModule {
         if (isChecked) {
             program.stop();
         }
-    }
-
-    @Override
-    public void onStart() {
-
-    }
-
-    @Override
-    public void onStop() {
-
     }
 }

--- a/debugdrawer-glide/src/main/java/io/palaima/debugdrawer/glide/GlideModule.java
+++ b/debugdrawer-glide/src/main/java/io/palaima/debugdrawer/glide/GlideModule.java
@@ -13,9 +13,9 @@ import com.bumptech.glide.load.engine.cache.MemoryCache;
 
 import java.lang.reflect.Field;
 
-import io.palaima.debugdrawer.base.DebugModule;
+import io.palaima.debugdrawer.base.DebugModuleAdapter;
 
-public class GlideModule implements DebugModule {
+public class GlideModule extends DebugModuleAdapter {
 
     private static final boolean HAS_GLIDE;
 
@@ -92,24 +92,8 @@ public class GlideModule implements DebugModule {
         refresh();
     }
 
-    @Override public void onClosed() {
-
-    }
-
     @Override public void onResume() {
         refresh();
-    }
-
-    @Override public void onPause() {
-
-    }
-
-    @Override public void onStart() {
-
-    }
-
-    @Override public void onStop() {
-
     }
 
     private void refresh() {

--- a/debugdrawer-okhttp/src/main/java/io/palaima/debugdrawer/okhttp/OkHttpModule.java
+++ b/debugdrawer-okhttp/src/main/java/io/palaima/debugdrawer/okhttp/OkHttpModule.java
@@ -8,9 +8,9 @@ import android.widget.TextView;
 
 import com.squareup.okhttp.OkHttpClient;
 
-import io.palaima.debugdrawer.base.DebugModule;
+import io.palaima.debugdrawer.base.DebugModuleAdapter;
 
-public class OkHttpModule implements DebugModule {
+public class OkHttpModule extends DebugModuleAdapter {
 
     private static final boolean HAS_OKHTTP;
 
@@ -84,31 +84,6 @@ public class OkHttpModule implements DebugModule {
     @Override
     public void onOpened() {
         refresh();
-    }
-
-    @Override
-    public void onClosed() {
-
-    }
-
-    @Override
-    public void onResume() {
-
-    }
-
-    @Override
-    public void onPause() {
-
-    }
-
-    @Override
-    public void onStart() {
-
-    }
-
-    @Override
-    public void onStop() {
-
     }
 
     private static String sizeString(long bytes) {

--- a/debugdrawer-okhttp3/src/main/java/io/palaima/debugdrawer/okhttp3/OkHttp3Module.java
+++ b/debugdrawer-okhttp3/src/main/java/io/palaima/debugdrawer/okhttp3/OkHttp3Module.java
@@ -6,10 +6,10 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
 
-import io.palaima.debugdrawer.base.DebugModule;
+import io.palaima.debugdrawer.base.DebugModuleAdapter;
 import okhttp3.OkHttpClient;
 
-public class OkHttp3Module implements DebugModule {
+public class OkHttp3Module extends DebugModuleAdapter {
 
     private static final boolean HAS_OKHTTP3;
 
@@ -83,31 +83,6 @@ public class OkHttp3Module implements DebugModule {
     @Override
     public void onOpened() {
         refresh();
-    }
-
-    @Override
-    public void onClosed() {
-
-    }
-
-    @Override
-    public void onResume() {
-
-    }
-
-    @Override
-    public void onPause() {
-
-    }
-
-    @Override
-    public void onStart() {
-
-    }
-
-    @Override
-    public void onStop() {
-
     }
 
     private static String sizeString(long bytes) {

--- a/debugdrawer-picasso/src/main/java/io/palaima/debugdrawer/picasso/PicassoModule.java
+++ b/debugdrawer-picasso/src/main/java/io/palaima/debugdrawer/picasso/PicassoModule.java
@@ -12,8 +12,9 @@ import com.squareup.picasso.Picasso;
 import com.squareup.picasso.StatsSnapshot;
 
 import io.palaima.debugdrawer.base.DebugModule;
+import io.palaima.debugdrawer.base.DebugModuleAdapter;
 
-public class PicassoModule implements DebugModule {
+public class PicassoModule extends DebugModuleAdapter {
 
     private static final boolean HAS_PICASSO;
 
@@ -88,21 +89,6 @@ public class PicassoModule implements DebugModule {
         refresh();
     }
 
-    @Override
-    public void onClosed() {
-
-    }
-
-    @Override
-    public void onResume() {
-
-    }
-
-    @Override
-    public void onPause() {
-
-    }
-
     private void refresh() {
         StatsSnapshot snapshot = picasso.getSnapshot();
         String size = getSizeString(snapshot.size);
@@ -117,16 +103,6 @@ public class PicassoModule implements DebugModule {
         transformedLabel.setText(String.valueOf(snapshot.transformedBitmapCount));
         transformedTotalLabel.setText(getSizeString(snapshot.totalTransformedBitmapSize));
         transformedAverageLabel.setText(getSizeString(snapshot.averageTransformedBitmapSize));
-    }
-
-    @Override
-    public void onStart() {
-
-    }
-
-    @Override
-    public void onStop() {
-
     }
 
     private static String getSizeString(long bytes) {

--- a/debugdrawer-scalpel/src/main/java/io/palaima/debugdrawer/scalpel/ScalpelModule.java
+++ b/debugdrawer-scalpel/src/main/java/io/palaima/debugdrawer/scalpel/ScalpelModule.java
@@ -13,9 +13,9 @@ import android.widget.Switch;
 
 import com.jakewharton.scalpel.ScalpelFrameLayout;
 
-import io.palaima.debugdrawer.base.DebugModule;
+import io.palaima.debugdrawer.base.DebugModuleAdapter;
 
-public class ScalpelModule implements DebugModule {
+public class ScalpelModule extends DebugModuleAdapter {
 
     private static final boolean HAS_SCALPEL;
 
@@ -83,35 +83,5 @@ public class ScalpelModule implements DebugModule {
         });
 
         return view;
-    }
-
-    @Override
-    public void onOpened() {
-
-    }
-
-    @Override
-    public void onClosed() {
-
-    }
-
-    @Override
-    public void onResume() {
-
-    }
-
-    @Override
-    public void onPause() {
-
-    }
-
-    @Override
-    public void onStart() {
-
-    }
-
-    @Override
-    public void onStop() {
-
     }
 }

--- a/debugdrawer-timber/src/main/java/io/palaima/debugdrawer/timber/TimberModule.java
+++ b/debugdrawer-timber/src/main/java/io/palaima/debugdrawer/timber/TimberModule.java
@@ -5,10 +5,10 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
-import io.palaima.debugdrawer.base.DebugModule;
+import io.palaima.debugdrawer.base.DebugModuleAdapter;
 import io.palaima.debugdrawer.timber.ui.LogDialog;
 
-public class TimberModule implements DebugModule {
+public class TimberModule extends DebugModuleAdapter {
 
     @NonNull
     @Override
@@ -23,35 +23,5 @@ public class TimberModule implements DebugModule {
         });
 
         return view;
-    }
-
-    @Override
-    public void onOpened() {
-
-    }
-
-    @Override
-    public void onClosed() {
-
-    }
-
-    @Override
-    public void onResume() {
-
-    }
-
-    @Override
-    public void onPause() {
-
-    }
-
-    @Override
-    public void onStart() {
-
-    }
-
-    @Override
-    public void onStop() {
-
     }
 }


### PR DESCRIPTION
Few modules override all 7 methods of DebugModule, lot of them keep all lifecycle and visibility methods empty. So we can introduce abstract adapter class, which allow module developers keep their code clean of boilerplate.