### PR TITLE
proguard rule for GlideModule

### DIFF
--- a/debugdrawer-glide/proguard-rules.pro
+++ b/debugdrawer-glide/proguard-rules.pro
@@ -15,3 +15,10 @@
 #-keepclassmembers class fqcn.of.javascript.interface.for.webview {
 #   public *;
 #}
+
+# GlideModule uses reflection to access memoryCache field in Glide instance
+# and if proguard is enabled(release build for example) an exception is thrown
+# that no such field exists because the field was obfuscated
+-keepclassmembers class com.bumptech.glide.Glide {
+    private com.bumptech.glide.load.engine.cache.MemoryCache memoryCache;
+}


### PR DESCRIPTION
NoSuchFieldException fix for projects that use proguard to obfuscate Glide code.