### PR TITLE
Compare activity that is destroyed to the owner of the debug drawer, …

### DIFF
--- a/debugdrawer/src/main/java/io/palaima/debugdrawer/DebugDrawerLifecycleCallbacks.java
+++ b/debugdrawer/src/main/java/io/palaima/debugdrawer/DebugDrawerLifecycleCallbacks.java
@@ -53,8 +53,10 @@ final class DebugDrawerLifecycleCallbacks implements Application.ActivityLifecyc
 
     @Override
     public void onActivityDestroyed(Activity activity) {
-        this.activity.getApplication().unregisterActivityLifecycleCallbacks(this);
-        this.activity = null;
-        debugDrawer = null;
+        if (this.activity == activity) {
+            this.activity.getApplication().unregisterActivityLifecycleCallbacks(this);
+            this.activity = null;
+            debugDrawer = null;
+        }
     }
 }


### PR DESCRIPTION
…so that only the owner being destroyed removes drawer lifecycle handling. Otherwise drawer modules become unresponsive when any activity is destroyed.

See https://github.com/palaima/DebugDrawer/issues/98